### PR TITLE
Update WOZObject.json

### DIFF
--- a/data/woz/WOZObject.json
+++ b/data/woz/WOZObject.json
@@ -10,7 +10,7 @@
     "waarde": 171000
   },
   {
-    "identificatie": "xxxx",
+    "identificatie": "051800638803",
     "adresseerbaarObjectIdentificatie": "0518010000410621",
     "waarde": 2170000
   },
@@ -30,7 +30,7 @@
     "waarde": 4123700
   },
   {
-    "identificatie": "xxxx",
+    "identificatie": "051800909337",
     "adresseerbaarObjectIdentificatie": "0518010001752111",
     "waarde": 23543000
   },


### PR DESCRIPTION
Voor objecten zonder identificatie is geen WOZ-waarde openbaar. Dit geeft fouten in de orkestratie-engine.